### PR TITLE
Give /snapraid/v1/hold_off OpenAPI spec a defined response

### DIFF
--- a/snapraidd.yaml
+++ b/snapraidd.yaml
@@ -63,8 +63,15 @@ paths:
                     Set to false to resume the normal
                     maintenance schedule.
       responses:
-        200:
+        '200':
           description: "Hold-off state updated successfully"
+          $ref: '#/components/responses/CommandResult'
+        '400':
+          description: "Invalid request body."
+          $ref: '#/components/responses/CommandResult'
+        '405':
+          description: "Invalid method."
+          $ref: '#/components/responses/CommandResult' 
 
   /snapraid/v1/heal:
     post:


### PR DESCRIPTION
The hold_ff path did not define a response, which some generators appear to have an issue with 

```
❯ uvx openapi-python-client generate --path ./snapraidd.yaml
Error(s) encountered while generating, client was not created

Failed to parse OpenAPI document

1 validation error for OpenAPI
paths./snapraid/v1/hold_off.post.responses.200.[key]
  Input should be a valid string [type=string_type, input_value=200, input_type=int]
    For further information visit https://errors.pydantic.dev/2.13/v/string_type


If you believe this was a mistake or this tool is missing a feature you need, please open an issue at https://github.com/openapi-generators/openapi-python-client/issues/new/choose
```

With this fix the generator can correctly create a client 

```
snapraid-daemon on  hoage/repair-holdoff-openapi
❯ uvx openapi-python-client generate --path ./snapraidd.yaml
Generating /home/chris/projects/github/snapraid-daemon/snap-raid-api-client
```

Looking a the C code it looks like this endpoint follows the same pattern as the others, but if this is not correct let me know and I will adjust the yaml 